### PR TITLE
Update page footer to use updated themefisher link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -154,7 +154,7 @@
                     <li><a href="https://www.linkedin.com/company/cucyber/"><i class="fab fa-linkedin-in fa-2x"></i></a></li>
                     <li><a href="https://twitter.com/CU_Cyber"><i class="fab fa-twitter fa-2x"></i></a></li>
                 </ul>
-                <p class="copyright">Copyright: <span>2020</span> CU Cyber &lt;cyber@clemson.edu&gt;. Design and Developed by <a href="http://www.Themefisher.com">Themefisher</a></p>
+                <p class="copyright">Copyright: <span>2020</span> CU Cyber &lt;cyber@clemson.edu&gt;. Design and Developed by <a href="https://themefisher.com">Themefisher</a></p>
             </div>
         </footer> <!-- /#footer -->
     </body>


### PR DESCRIPTION
Resolves #34, by removing the `www` from the link, changing the capitalization of the `t`, and changing the protocol from `http` to `https`.

A minor fix really.