### PR TITLE
Add fullcalendar version of events page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,6 +41,10 @@
         <link rel="stylesheet" href="/css/main.css">
         <!-- responsive css -->
         <link rel="stylesheet" href="/css/responsive.css">
+        <link rel="stylesheet" href="https://unpkg.com/@fullcalendar/core@4.4.0/main.min.css">
+        <link rel="stylesheet" href="https://unpkg.com/@fullcalendar/bootstrap@4.4.0/main.min.css">
+        <link rel="stylesheet" href="https://unpkg.com/@fullcalendar/daygrid@4.4.0/main.min.css">
+        <link rel="stylesheet" href="https://unpkg.com/@fullcalendar/list@4.4.0/main.min.css">
 
         <!-- Template Javascript Files
         ================================================== -->
@@ -53,7 +57,6 @@
         <!-- owl carouserl js -->
         <script src="/js/owl.carousel.min.js"></script>
         <!-- bootstrap js -->
-
         <script src="/js/bootstrap.min.js"></script>
         <!-- wow js -->
         <script src="/js/wow.min.js"></script>
@@ -64,6 +67,12 @@
         <script src="/js/main.js"></script>
         <!-- icons js -->
         <script src="https://kit.fontawesome.com/8f683739d8.js"></script>
+        <!-- fullcalendar js -->
+        <script src="https://unpkg.com/@fullcalendar/core@4.4.0/main.min.js"></script>
+        <script src="https://unpkg.com/@fullcalendar/bootstrap@4.4.0/main.min.js"></script>
+        <script src="https://unpkg.com/@fullcalendar/google-calendar@4.4.0/main.min.js"></script>
+        <script src="https://unpkg.com/@fullcalendar/daygrid@4.4.0/main.min.js"></script>
+        <script src="https://unpkg.com/@fullcalendar/list@4.4.0/main.min.js"></script>
     </head>
     <body>
         <!--

--- a/css/main.css
+++ b/css/main.css
@@ -1402,6 +1402,7 @@ article {
 #calendar {
   max-width: 900px;
   margin: 40px auto;
+  padding: 0 20px;
 }
 
 .iframe-presentation {

--- a/css/main.css
+++ b/css/main.css
@@ -1399,6 +1399,11 @@ article {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
+#calendar {
+  max-width: 900px;
+  margin: 40px auto;
+}
+
 .iframe-presentation {
   display: block;
   width: 100%;

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -222,3 +222,8 @@ px      68    160    252    */
 ------------------------------------------------------------
 cols    1     2      3      4      5
 px      68    160    252    344    436    */
+@media only screen and (max-width: 480px) {
+  .fc-today-button {
+    display: none;
+  }
+}

--- a/events.html
+++ b/events.html
@@ -9,7 +9,25 @@ breadcrumbs:
     - Home: '/'
 ---
 <section id="blog-full-width">
-    <div class="text-center">
-        <iframe src="https://calendar.google.com/calendar/b/1/embed?height=650&amp;wkst=2&amp;bgcolor=%23F09300&amp;ctz=America%2FNew_York&amp;src=cHRqdDg5NWo2dG5jY2EydTVnZGdlNjNwdmdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23F09300&amp;mode=MONTH" style="border-width:0" width="1200" height="500" frameborder="0" scrolling="no"></iframe>
-    </div>
+    <div class="text-center"><a href="https://calendar.google.com/calendar?cid=cHRqdDg5NWo2dG5jY2EydTVnZGdlNjNwdmdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ">Add club events to your Google Calendar!</a></div>
+
+    <div id="calendar"></div>
+    <script>
+        var calendar;
+        window.addEventListener('load', function(ev) {
+            calendar = new FullCalendar.Calendar(document.getElementById('calendar'), {
+                plugins: ['bootstrap', 'dayGrid', 'list', 'googleCalendar'],
+                themeSystem: 'bootstrap',
+                header: {
+                    left: 'prev,next today',
+                    center: 'title',
+                    right: 'dayGridMonth,listMonth'
+                },
+                googleCalendarApiKey: 'AIzaSyA7zJnQujsXxaDhPRVulvBy-X6XRuxxvf8',
+                events: 'ptjt895j6tncca2u5gdge63pvg@group.calendar.google.com'
+            });
+
+            calendar.render();
+        }, false);
+    </script>
 </section>


### PR DESCRIPTION
I made a simple implementation of https://fullcalendar.io/ for the events page that looks and works better than the GCal iframe and has better potential to look alright on mobile since we can actually work with it.

It is inheriting its colors from the Bootstrap that's already on the page but they can still be messed with pretty easily. Mobile doesn't look 100% but if we want, reducing the footprint by making the `header` piece smaller and maybe defaulting to list view might be sufficient for responsiveness.

See: https://fullcalendar.dev.cucyber.net/events.html

Closes #32 