### PR TITLE
Add Open Graph tags to show cool stuff when posted on social media

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,9 @@
+name: CU Cyber
+url: https://cucyber.net
+twitter: '@CU_Cyber'
+description: |
+  CU Cyber is a student led organization at Clemson University that focuses on the technical and social aspects of cyber security
+
 timezone: America/New_York
 
 keep_files: ['class', 'documents', 'presentations', 'wiki']

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,15 +5,23 @@
         ================================================== -->
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
         <link rel="icon" type="image/png" href="/images/shield-small.png">
-        <title>CU Cyber{% if page.title %} - {{ page.title }}{% endif %}</title>
+        <title>{{ site.name }}{% if page.title %} - {{ page.title }}{% endif %}</title>
         <link rel="shortcut icon" href="/images/shield-small.png">
-        <meta name="description" content="">
-        <meta name="keywords" content="">
-        <meta name="author" content="">
+        <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
         <!-- Mobile Specific Metas
         ================================================== -->
         <meta name="format-detection" content="telephone=no">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- Social Media Info
+        ================================================== -->
+        <meta property="og:title" content="{{ site.name }}{% if page.title %} - {{ page.title }}{% endif %}">
+        <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
+        <meta property="og:image" content="{{ site.url }}{% if page.image %}{{ page.image }}{% else %}/images/shield.png{% endif %}">
+        <meta property="og:url" content="{{ site.url }}{{ page.url }}">
+        <meta property="og:site_name" content="{{ site.name }}">
+        <meta name="twitter:site" content="{{ site.twitter }}">
+        <meta name="twitter:card" content="summary_large_image">
+
 
         <!-- Template CSS Files
         ================================================== -->


### PR DESCRIPTION
I added central site info and open graph tags that contains an image and description that can be overridden by page (site name will be pulled globally and title will be same as page title).

Try posting this in Discord or Twitter or Facebook or Slack or whatever to test: https://opengraph.dev.cucyber.net/

Reference: https://ogp.me