### PR TITLE
Add Additional Social Media Icons/Links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -172,6 +172,7 @@
                     <li><a href="https://www.instagram.com/cucyber/"><i class="fab fa-instagram fa-2x"></i></a></li>
                     <li><a href="https://www.linkedin.com/groups/12049268/"><i class="fab fa-linkedin-in fa-2x"></i></a></li>
                     <li><a href="https://twitter.com/CU_Cyber"><i class="fab fa-twitter fa-2x"></i></a></li>
+                    <li><a href="https://www.youtube.com/channel/UCpnGCvDSNgxOVrN34eUlS-Q"><i class="fab fa-youtube fa-2x"></i></a><li>
                 </ul>
                 <p class="copyright">Copyright: <span>2020</span> CU Cyber &lt;cyber@clemson.edu&gt;. Design and Developed by <a href="https://themefisher.com">Themefisher</a></p>
             </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -169,6 +169,7 @@
             <div class="container">
                 <ul class="list-inline text-center">
                     <li><a href="https://discord.gg/f7ZcC7z"><i class="fab fa-discord fa-2x"></i></a></li>
+                    <li><a href="https://www.instagram.com/cucyber/"><i class="fab fa-instagram fa-2x"></i></a></li>
                     <li><a href="https://www.linkedin.com/groups/12049268/"><i class="fab fa-linkedin-in fa-2x"></i></a></li>
                     <li><a href="https://twitter.com/CU_Cyber"><i class="fab fa-twitter fa-2x"></i></a></li>
                 </ul>


### PR DESCRIPTION
Add in additional links for our Instagram and YouTube pages to the bottom of the page.

Added in so that sites are in alphabetical order, i.e.:

- Discord
- Instagram
- LinkedIn
- Twitter
- YouTube