### PR TITLE
Remove "Home" Link in Navigation Bar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -104,7 +104,6 @@
                 <nav class="collapse navbar-collapse navbar-right" role="navigation">
                     <div class="main-menu">
                         <ul class="flat nav navbar-nav navbar-right">
-                            <li><a href="/">Home</a></li>
                             <li><a href="/about">About</a></li>
                             <li><a href="/events">Events</a></li>
                             <li><a href="/contact">Contact us</a></li>


### PR DESCRIPTION
Having both a "Home" option and the brand image/logo both in the navigation bar pointing to the same location is redundant, especially with the presence of breadcrumbs in pages.

closes #30