### PR TITLE
Remove unused owl carousel css imports and clients references

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,9 +32,7 @@
         <link rel="stylesheet" href="https://unpkg.com/animate.css@3.7.2/animate.min.css" integrity="sha512-doJrC/ocU8VGVRx3O9981+2aYUn3fuWVWvqLi1U+tA2MWVzsw+NVKq1PrENF03M+TYBP92PnYUlXFH1ZW0FpLw==" crossorigin="anonymous">
         <!-- Hero area slider css-->
         <link rel="stylesheet" href="/css/slider.css">
-        <!-- owl craousel css -->
-        <link rel="stylesheet" href="https://unpkg.com/owl.carousel@2.3.4/dist/assets/owl.carousel.min.css" integrity="sha512-tS3S5qG0BlhnQROyJXvNjeEM4UpMXHrQfTGmbQ1gKmelCxlSEBUaxhRBj/EFTzpbP4RVSrpEikbmdJobCvhE3g==" crossorigin="anonymous">
-        <link rel="stylesheet" href="https://unpkg.com/owl.carousel@2.3.4/dist/assets/owl.theme.default.min.css" integrity="sha512-sMXtMNL1zRzolHYKEujM2AqCLUR9F2C4/05cdbxjjLSRvMQIciEPCQZo++nk7go3BtSuK9kfa/s+a4f4i5pLkw==" crossorigin="anonymous">
+        <!-- fancybox css-->
         <link rel="stylesheet" href="https://unpkg.com/jquery.fancybox@2.1.5/source/jquery.fancybox.css" integrity="sha512-Q3Vew98bTOHNPS36lEFNZ4Bf8VvFo90mRRftC6BJrkSps6uKUmcCGFDWQaYyn2j5j/QbLizpF6EmwTf59UnZ0A==" crossorigin="anonymous">
         <!-- template main css file -->
         <link rel="stylesheet" href="/css/main.css">
@@ -52,14 +50,13 @@
         <script src="/js/vendor/modernizr-2.6.2.min.js"></script>
         <!-- jquery -->
         <script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" integrity="sha512-jGsMH83oKe9asCpkOVkBnUrDDTp8wl+adkB2D+//JtlxO4SrLoJdhbOysIFQJloQFD+C4Fl1rMsQZF76JjV0eQ==" crossorigin="anonymous"></script>
-        <!-- owl carouserl js -->
-        <script src="https://unpkg.com/owl.carousel@2.3.4/dist/owl.carousel.min.js" integrity="sha512-bPs7Ae6pVvhOSiIcyUClR7/q2OAsRiovw4vAkX+zJbw3ShAeeqezq50RIIcIURq7Oa20rW2n2q+fyXBNcU9lrw==" crossorigin="anonymous"></script>
         <!-- bootstrap js -->
         <script src="https://unpkg.com/bootstrap@3.4.1/dist/js/bootstrap.min.js" integrity="sha512-oBTprMeNEKCnqfuqKd6sbvFzmFQtlXS3e0C/RGFV0hD6QzhHV+ODfaQbAlmY6/q0ubbwlAM/nCJjkrgA3waLzg==" crossorigin="anonymous"></script>
         <!-- wow js -->
         <script src="https://unpkg.com/wowjs@1.1.3/dist/wow.min.js" integrity="sha512-GzfUS5tsgmQn8eElgtjl+pslWuz/hohQAjI17n7I1O1EAVR5IvEdLV3wnTu8OC3Tfr/B/0I3BR1T9LTphS0X2A==" crossorigin="anonymous"></script>
         <!-- slider js -->
         <script src="/js/slider.js"></script>
+        <!-- fancybox js -->
         <script src="https://unpkg.com/jquery.fancybox@2.1.5/source/jquery.fancybox.js" integrity="sha512-CDTvYKbOXv86JIBa5/TWFZkE+4zMptqAJ+YBUySh7RRNxf0QEtjPaGgKbIHEkYj7eNGiVdRkhlhSUeKuvFQ/0w==" crossorigin="anonymous"></script>
         <!-- template main js -->
         <script src="/js/main.js"></script>

--- a/css/main.css
+++ b/css/main.css
@@ -904,20 +904,6 @@ ul.social-icons li {
   left: 13%;
 }
 
-#clients {
-  padding: 30px 0 60px;
-}
-
-#clients .owl-carousel .owl-item img {
-  display: block;
-  width: 100%;
-  -webkit-transform-style: preserve-3d;
-}
-
-#clients .owl-carousel .owl-item {
-  margin-right: 10px;
-}
-
 .works-fit {
   padding: 40px 0;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -43,12 +43,6 @@ $(document).ready(function() {
             $('#top-bar').addClass('animated-header');
     });
 
-    $('#clients-logo').owlCarousel({
-        itemsCustom : false,
-        pagination : false,
-        items : 5,
-        autoplay: true,
-    });
 });
 
 $('.fancybox').fancybox({


### PR DESCRIPTION
So far as I can see, the owl carousel was added as part of the initial Themefisher template as part of the "Clients" page, but since we replaced that with our events page (originally a blog, now just a calendar), it seems unnecessary.