### PR TITLE
Update invite link to the discord server

### DIFF
--- a/discord.html
+++ b/discord.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; URL=https://discord.gg/ESZbncHjDC" />
+<meta http-equiv="refresh" content="0; URL=https://discord.gg/f7ZcC7z" />


### PR DESCRIPTION
Fix the discord invite link at `https://cucyber.net/discord` since the old one was deleted.