### PR TITLE
Update meeting information in the contact and about pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -74,7 +74,7 @@ breadcrumbs:
                         Weekly Meetings
                     </h2>
                     <p>
-                        CU Cyber meetings are held Thursdays at 7pm in the Watt Family Innovation Center room 208.<br/><br/>
+                        CU Cyber meetings are held Thursdays at 7pm in the Watt Family Innovation Center room 308.<br/><br/>
                         We will cover security topics and tools in these meetings that can be applied to your professional and daily life.
                     </p>
                 </div>

--- a/contact.html
+++ b/contact.html
@@ -108,9 +108,9 @@ breadcrumbs:
             <div class="col-lg-6">
                 <div class="map-area">
                     <div class="text-center">
-                        <h2 class="subtitle wow fadeInDown" data-wow-duration="500ms" data-wow-delay=".3s">Find us in the Watt Center room 208</h2>
+                        <h2 class="subtitle wow fadeInDown" data-wow-duration="500ms" data-wow-delay=".3s">Find us in the Watt Center room 308</h2>
                         <p class="subtitle-des wow fadeInDown" data-wow-duration="500ms" data-wow-delay=".5s">
-                            We meet weekly on Thursdays at 7:00 PM in the Watt Center room 208, so come check us out!
+                            We meet weekly on Thursdays at 7:00 PM in the Watt Center room 308, so come check us out!
                         </p><br>
                     </div>
                     <div class="map text-center">


### PR DESCRIPTION
Updates the location in the contact and about pages to reflect room 308 instead of room 208 for our weekly meetings.